### PR TITLE
Reset the minor package versions when bumping/deploying

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -76,8 +76,11 @@ def bump(c, part, commit=True, tag=True, deploy=True):
     major, minor, patch = map(int, current_version.split('.'))
     if part == 'major':
         major += 1
+        minor = 0
+        patch = 0
     elif part == 'minor':
         minor += 1
+        patch = 0
     elif part == 'patch':
         patch += 1
     else:


### PR DESCRIPTION
The individual versions were previously bumped independently when deploying instead of resetting the more minor versions to zero. This fixes that behavior.
