### PR TITLE
Add support for item access, iteration, deletion, contains, and stack levels

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -129,14 +129,13 @@ class Dysco:
             del current_frame
 
     def __setitem__(self, key: str, value: Any) -> None:
-        read_only = getattr(self, '_Dysco_read_only', False)
         stack = inspect.stack()
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
         try:
             initial_scope = Scope(stack[0].frame, namespace=hex(id(self)))
             scope = initial_scope
-            while not read_only and scope:
+            while not self.__read_only and scope:
                 if key in scope.variables:
                     scope.variables[key] = value
                     return

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -1,7 +1,7 @@
 """Houses the implementation of the main ``Dysco`` class and project API."""
 import inspect
 from threading import Lock
-from typing import Any, Hashable, Iterator, List, Tuple
+from typing import Any, Hashable, Iterator, Tuple
 
 from dysco.scope import Scope, find_parent_scope
 

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -63,13 +63,12 @@ class Dysco:
         stack = inspect.stack()
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
-        key_value_pairs: List[Tuple[Hashable, Any]] = []
         try:
             scope = Scope(stack[0].frame, namespace=hex(id(self)))
             while scope:
-                key_value_pairs += scope.variables.items()
+                for key_value_pair in scope.variables.items():
+                    yield key_value_pair
                 scope, stack = find_parent_scope(scope, stack)
-            return iter(key_value_pairs)
         finally:
             # Delete the current frame to avoid reference cycles.
             del current_frame

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -1,26 +1,41 @@
 """Houses the implementation of the main ``Dysco`` class and project API."""
 import inspect
-from typing import Any
+from typing import Any, Hashable
 
 from dysco.scope import Scope, find_parent_scope
 
 
 class Dysco:
-    def __init__(self, read_only: bool = False):
+    def __init__(self, read_only: bool = False, stacklevel: int = 1):
         self.__read_only = read_only
+        self.__stacklevel = stacklevel
 
     def __getattr__(self, attribute: str) -> Any:
         if attribute.startswith('_Dysco_'):
             return super().__getattribute__(attribute)
+
+        try:
+            current_frame = inspect.currentframe()
+            self.__stacklevel += 1
+            return self[attribute]
+        except KeyError:
+            raise AttributeError(f'The attribute {attribute} was not found in any scope.')
+        finally:
+            self.__stacklevel -= 1
+            # Delete the current frame to avoid reference cycles.
+            del current_frame
+
+    def __getitem__(self, key: Hashable) -> Any:
         stack = inspect.stack()
-        current_frame = stack.pop(0).frame
+        current_frame = stack[0].frame
+        stack = stack[self.__stacklevel :]
         try:
             scope = Scope(stack[0].frame, namespace=hex(id(self)))
             while scope:
-                if attribute in scope.variables:
-                    return scope.variables[attribute]
+                if key in scope.variables:
+                    return scope.variables[key]
                 scope, stack = find_parent_scope(scope, stack)
-            raise AttributeError(f'The attribute {attribute} was not found in any scope.')
+            raise KeyError(f'The key "{key}" was not found in any scope.')
         finally:
             # Delete the current frame to avoid reference cycles.
             del current_frame
@@ -28,18 +43,31 @@ class Dysco:
     def __setattr__(self, attribute: str, value: Any) -> None:
         if attribute.startswith('_Dysco_'):
             super().__setattr__(attribute, value)
+            return
+
+        try:
+            current_frame = inspect.currentframe()
+            self.__stacklevel += 1
+            self[attribute] = value
+        finally:
+            self.__stacklevel -= 1
+            # Delete the current frame to avoid reference cycles.
+            del current_frame
+
+    def __setitem__(self, key: str, value: Any) -> None:
         read_only = getattr(self, '_Dysco_read_only', False)
         stack = inspect.stack()
-        current_frame = stack.pop(0).frame
+        current_frame = stack[0].frame
+        stack = stack[self.__stacklevel :]
         try:
             initial_scope = Scope(stack[0].frame, namespace=hex(id(self)))
             scope = initial_scope
             while not read_only and scope:
-                if attribute in scope.variables:
-                    scope.variables[attribute] = value
+                if key in scope.variables:
+                    scope.variables[key] = value
                     return
                 scope, stack = find_parent_scope(scope, stack)
-            initial_scope.variables[attribute] = value
+            initial_scope.variables[key] = value
         finally:
             # Delete the current frame to avoid reference cycles.
             del current_frame

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -12,6 +12,21 @@ class Dysco:
         self.__stacklevel = stacklevel
         self.__stacklevel_lock = Lock()
 
+    def __contains__(self, key: Hashable) -> bool:
+        try:
+            current_frame = inspect.currentframe()
+            self.__stacklevel_lock.acquire()
+            self.__stacklevel += 1
+            self[key]
+            return True
+        except KeyError:
+            return False
+        finally:
+            self.__stacklevel -= 1
+            self.__stacklevel_lock.release()
+            # Delete the current frame to avoid reference cycles.
+            del current_frame
+
     def __getattr__(self, attribute: str) -> Any:
         if attribute.startswith('_Dysco_'):
             return super().__getattribute__(attribute)

--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -1,7 +1,7 @@
 import weakref
 from inspect import FrameInfo
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set
 from weakref import WeakValueDictionary
 
 from slugify import slugify
@@ -60,7 +60,7 @@ class Scope:
 
         self.name = construct_name(frame, namespace)
         self.namespace = namespace
-        self.variables: Dict[str, Any] = {}
+        self.variables: Dict[Hashable, Any] = {}
 
         scopes_by_name[self.name] = self
         frame.f_locals[self.name] = self

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -3,7 +3,12 @@ import pytest
 from dysco import g
 
 
-def test_item_access():
+def test_item_tuple_access():
+    g[(1, 'hi')] = True
+    assert g[(1, 'hi')] == True
+
+
+def test_item_attribute_interoperability():
     g.hello = 1
     assert g['hello'] == 1
     g['hello'] = 2

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -1,3 +1,5 @@
+from sys import version_info
+
 import pytest
 
 from dysco import Dysco, g
@@ -18,6 +20,18 @@ def test_hasattr():
 def test_item_tuple_access():
     g[(1, 'hi')] = True
     assert g[(1, 'hi')] == True
+
+
+def test_dict_conversion():
+    g.set_in_outer = 1
+
+    def test_inner():
+        g.set_in_inner = 2
+        assert dict(g) == {'set_in_inner': 2, 'set_in_outer': 1}
+        if version_info[0] > 3 or version_info[1] >= 7:
+            assert (
+                dict(g).keys()[0] == 'set_in_inner'
+            ), 'Variables set in lower scopes should be ordered first.'
 
 
 def test_item_attribute_interoperability():

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -9,6 +9,12 @@ def test_contains():
     assert 'hi' in g
 
 
+def test_hasattr():
+    assert not hasattr(g, 'hi')
+    g['hi'] = True
+    assert hasattr(g, 'hi')
+
+
 def test_item_tuple_access():
     g[(1, 'hi')] = True
     assert g[(1, 'hi')] == True

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dysco import g
+from dysco import Dysco, g
 
 
 def test_item_tuple_access():
@@ -50,3 +50,23 @@ def test_scope_isolation():
     test_second()
     assert g.first == 1
     assert g.second == 2
+
+
+def test_stacklevel_option():
+    dysco = Dysco(stacklevel=2)
+
+    def set(key, value):
+        dysco[key] = value
+
+    def nested_set(key, value):
+        set(key, value)
+
+    def get(key):
+        return dysco[key]
+
+    set('a', 1)
+    assert get('a') == 1
+
+    nested_set('b', 1)
+    with pytest.raises(KeyError):
+        get('b')

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -3,6 +3,12 @@ import pytest
 from dysco import Dysco, g
 
 
+def test_contains():
+    assert 'hi' not in g
+    g['hi'] = True
+    assert 'hi' in g
+
+
 def test_item_tuple_access():
     g[(1, 'hi')] = True
     assert g[(1, 'hi')] == True

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -11,17 +11,6 @@ def test_contains():
     assert 'hi' in g
 
 
-def test_hasattr():
-    assert not hasattr(g, 'hi')
-    g['hi'] = True
-    assert hasattr(g, 'hi')
-
-
-def test_item_tuple_access():
-    g[(1, 'hi')] = True
-    assert g[(1, 'hi')] == True
-
-
 def test_dict_conversion():
     g.set_in_outer = 1
 
@@ -32,6 +21,17 @@ def test_dict_conversion():
             assert (
                 dict(g).keys()[0] == 'set_in_inner'
             ), 'Variables set in lower scopes should be ordered first.'
+
+
+def test_hasattr():
+    assert not hasattr(g, 'hi')
+    g['hi'] = True
+    assert hasattr(g, 'hi')
+
+
+def test_item_tuple_access():
+    g[(1, 'hi')] = True
+    assert g[(1, 'hi')] == True
 
 
 def test_item_attribute_interoperability():

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -3,6 +3,14 @@ import pytest
 from dysco import g
 
 
+def test_item_access():
+    g.hello = 1
+    assert g['hello'] == 1
+    g['hello'] = 2
+    assert g['hello'] == 2
+    assert g.hello == 2
+
+
 def test_scope_in_loops():
     g.hello = -1
     for i in range(20):

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -25,6 +25,24 @@ def test_deleting_items():
     assert 'something' not in g
 
 
+def test_deleting_items_in_readonly_mode():
+    # It should work fine in the same scope.
+    dysco = Dysco(read_only=True)
+    dysco['something'] = 1
+    assert 'something' in dysco
+    del dysco['something']
+    assert 'something' not in dysco
+
+    dysco['something'] = 1
+
+    def delete_in_inner_scope():
+        del dysco['something']
+
+    with pytest.raises(KeyError):
+        delete_in_inner_scope()
+    assert 'something' in dysco
+
+
 def test_dict_conversion():
     g.set_in_outer = 1
 

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -11,6 +11,20 @@ def test_contains():
     assert 'hi' in g
 
 
+def test_deleting_attributes():
+    g.something = 1
+    assert hasattr(g, 'something')
+    delattr(g, 'something')
+    assert not hasattr(g, 'something')
+
+
+def test_deleting_items():
+    g['something'] = 1
+    assert 'something' in g
+    del g['something']
+    assert 'something' not in g
+
+
 def test_dict_conversion():
     g.set_in_outer = 1
 


### PR DESCRIPTION
This defines a variety of Python magic methods such as `__getitem__()`, `__setitem__()`, `__delitem__()`, `__delattr__()`, `__contains__()`, and `__iter__()`. In order to implement these, I added a `stacklevel` option in analogy to the one used in various places in the standard library. The attribute access methods temporarily bump the stack level while deferring to the underlying item methods.
