### PR TITLE
Fix deleting dysco attributes

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -29,7 +29,7 @@ class Dysco:
 
     def __delattr__(self, attribute: str):
         if attribute.startswith('_Dysco_'):
-            return super().__getattribute__(attribute)
+            return super().__delattr__(attribute)
 
         try:
             current_frame = inspect.currentframe()

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -43,6 +43,14 @@ def test_deleting_items_in_readonly_mode():
     assert 'something' in dysco
 
 
+def test_deleting_private_attributes():
+    dysco = Dysco(read_only=True)
+    assert dysco._Dysco__read_only == True
+    del dysco._Dysco__read_only
+    with pytest.raises(AttributeError):
+        dysco.__read_only
+
+
 def test_dict_conversion():
     g.set_in_outer = 1
 


### PR DESCRIPTION
There was a typo and `__getattribute__()` was being called instead of `__delattr__()`.
