### PR TITLE
Raise a pickling error

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -1,5 +1,6 @@
 """Houses the implementation of the main ``Dysco`` class and project API."""
 import inspect
+from pickle import PickleError
 from threading import Lock
 from typing import Any, Hashable, Iterator, Tuple
 
@@ -111,6 +112,9 @@ class Dysco:
         finally:
             # Delete the current frame to avoid reference cycles.
             del current_frame
+
+    def __reduce__(self):
+        raise PickleError('Dysco cannot be pickled.')
 
     def __setattr__(self, attribute: str, value: Any) -> None:
         if attribute.startswith('_Dysco_'):

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -1,3 +1,4 @@
+import pickle
 from sys import version_info
 
 import pytest
@@ -82,6 +83,11 @@ def test_item_attribute_interoperability():
     g['hello'] = 2
     assert g['hello'] == 2
     assert g.hello == 2
+
+
+def test_pickling_fails():
+    with pytest.raises(pickle.PickleError):
+        pickle.dumps(g)
 
 
 def test_scope_in_loops():


### PR DESCRIPTION
This raises a pickling error when `Dysco.__reduce__()` is called.
