### PR TITLE
Add a shadow option and stricter behavior when read-only is enabled

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -38,7 +38,7 @@ class Dysco:
             self.__stacklevel += 1
             del self[attribute]
         except KeyError as key_error:
-            raise AttributeError(key_error.args[0].replace('key', 'attribute', count=1))
+            raise AttributeError(key_error.args[0].replace('key', 'attribute', 1))
         finally:
             self.__stacklevel -= 1
             self.__stacklevel_lock.release()

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -8,13 +8,13 @@ from dysco.scope import Scope, find_parent_scope
 
 
 class Dysco:
-    def __init__(self, read_only: bool = False, shadow: bool = False, stacklevel: int = 1):
-        if read_only and shadow:
+    def __init__(self, readonly: bool = False, shadow: bool = False, stacklevel: int = 1):
+        if readonly and shadow:
             raise ValueError(
-                'Only one of the "read_only" and "shadow" options can be used at the same time.'
+                'Only one of the "readonly" and "shadow" options can be used at the same time.'
             )
 
-        self.__read_only = read_only
+        self.__readonly = readonly
         self.__shadow = shadow
         self.__stacklevel = stacklevel
         self.__stacklevel_lock = Lock()
@@ -60,7 +60,7 @@ class Dysco:
             scope = initial_scope
             while scope:
                 if key in scope.variables:
-                    if self.__read_only and scope is not initial_scope:
+                    if self.__readonly and scope is not initial_scope:
                         raise KeyError(
                             f'The key "{key}" is defined in a higher scope, but is read-only.'
                         )
@@ -145,11 +145,11 @@ class Dysco:
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
         try:
-            initial_scope = Scope(stack[0].frame, namespace=hex(id(self)))
+            initial_scope = Scope(stack[0].frame, namespace=self.__namespace)
             scope = initial_scope
             while scope and not self.__shadow:
                 if key in scope.variables:
-                    if scope is initial_scope or not self.__read_only:
+                    if scope is initial_scope or not self.__readonly:
                         scope.variables[key] = value
                     else:
                         raise KeyError(

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -105,6 +105,21 @@ def test_pickling_fails():
         pickle.dumps(g)
 
 
+def test_read_only_option():
+    dysco = Dysco(read_only=True)
+    dysco.value = 1
+
+    def check_access():
+        dysco.inner_value = 2
+        with pytest.raises(AttributeError):
+            dysco.value = 3
+
+    check_access()
+
+    assert dysco.value == 1
+    assert 'inner_value' not in dysco
+
+
 def test_scope_in_loops():
     g.hello = -1
     for i in range(20):

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -156,6 +156,27 @@ def test_scope_isolation():
     assert g.second == 2
 
 
+def test_shadow_option():
+    with pytest.raises(ValueError):
+        dysco = Dysco(read_only=True, shadow=True)
+
+    dysco = Dysco(shadow=True)
+    dysco.value = 1
+
+    def check_access():
+        dysco.value = 2
+
+        def inner_check_access():
+            assert dysco.value == 2
+            dysco.value = 3
+
+        inner_check_access()
+        assert dysco.value == 2
+
+    check_access()
+    assert dysco.value == 1
+
+
 def test_stacklevel_option():
     dysco = Dysco(stacklevel=2)
 

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -43,7 +43,7 @@ def test_deleting_items():
 
 def test_deleting_items_in_readonly_mode():
     # It should work fine in the same scope.
-    dysco = Dysco(read_only=True)
+    dysco = Dysco(readonly=True)
     dysco['something'] = 1
     assert 'something' in dysco
     del dysco['something']
@@ -60,11 +60,11 @@ def test_deleting_items_in_readonly_mode():
 
 
 def test_deleting_private_attributes():
-    dysco = Dysco(read_only=True)
-    assert dysco._Dysco__read_only == True
-    del dysco._Dysco__read_only
+    dysco = Dysco(readonly=True)
+    assert dysco._Dysco__readonly == True
+    del dysco._Dysco__readonly
     with pytest.raises(AttributeError):
-        dysco.__read_only
+        dysco.__readonly
 
 
 def test_dict_conversion():
@@ -105,8 +105,8 @@ def test_pickling_fails():
         pickle.dumps(g)
 
 
-def test_read_only_option():
-    dysco = Dysco(read_only=True)
+def test_readonly_option():
+    dysco = Dysco(readonly=True)
     dysco.value = 1
 
     def check_access():
@@ -158,7 +158,7 @@ def test_scope_isolation():
 
 def test_shadow_option():
     with pytest.raises(ValueError):
-        dysco = Dysco(read_only=True, shadow=True)
+        dysco = Dysco(readonly=True, shadow=True)
 
     dysco = Dysco(shadow=True)
     dysco.value = 1


### PR DESCRIPTION
This adds a `shadow` parameter to the dysco class that will always write variables to the current scope regardless of whether a variable with the same name exists higher up the stack. This was previously the behavior of the read-only option. The read-only behavior has been updated to instead raise an exception if a matching variable is found further up the scope.
