### PR TITLE
Allow creating different configurations in the same namespace

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -22,10 +22,25 @@ class Dysco:
         self.__stacklevel_lock = Lock()
 
     def __call__(
-        self, readonly: Optional[bool] = None, stacklevel: Optional[int] = None
+        self,
+        readonly: Optional[bool] = None,
+        shadow: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
     ) -> 'Dysco':
+        if readonly and shadow:
+            raise ValueError(
+                'Only one of the "readonly" and "shadow" options can be used at the same time.'
+            )
+
         # Override the options if necessary, and construct a new instance with them.
-        readonly = self.__readonly if readonly is None else readonly
+        if readonly or shadow:
+            # Allow enabling one of these options without raising a value error in the init method.
+            readonly = bool(readonly)
+            shadow = not readonly
+        else:
+            # Otherwise pass through the existing values if new ones weren't given.
+            readonly = self.__readonly if readonly is None else readonly
+            shadow = self.__shadow if shadow is None else shadow
         stacklevel = self.__stacklevel if stacklevel is None else stacklevel
         dysco = Dysco(readonly=readonly, stacklevel=stacklevel)
 

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -14,6 +14,8 @@ class Dysco:
                 'Only one of the "readonly" and "shadow" options can be used at the same time.'
             )
 
+        self.__namespace = hex(id(self))
+
         self.__readonly = readonly
         self.__shadow = shadow
         self.__stacklevel = stacklevel
@@ -56,7 +58,7 @@ class Dysco:
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
         try:
-            initial_scope = Scope(stack[0].frame, namespace=hex(id(self)))
+            initial_scope = Scope(stack[0].frame, namespace=self.__namespace)
             scope = initial_scope
             while scope:
                 if key in scope.variables:
@@ -95,7 +97,7 @@ class Dysco:
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
         try:
-            scope = Scope(stack[0].frame, namespace=hex(id(self)))
+            scope = Scope(stack[0].frame, namespace=self.__namespace)
             while scope:
                 if key in scope.variables:
                     return scope.variables[key]
@@ -110,7 +112,7 @@ class Dysco:
         current_frame = stack[0].frame
         stack = stack[self.__stacklevel :]
         try:
-            scope = Scope(stack[0].frame, namespace=hex(id(self)))
+            scope = Scope(stack[0].frame, namespace=self.__namespace)
             while scope:
                 for key_value_pair in scope.variables.items():
                     yield key_value_pair

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -2,7 +2,7 @@
 import inspect
 from pickle import PickleError
 from threading import Lock
-from typing import Any, Hashable, Iterator, Tuple
+from typing import Any, Hashable, Iterator, Optional, Tuple
 
 from dysco.scope import Scope, find_parent_scope
 
@@ -20,6 +20,19 @@ class Dysco:
         self.__shadow = shadow
         self.__stacklevel = stacklevel
         self.__stacklevel_lock = Lock()
+
+    def __call__(
+        self, readonly: Optional[bool] = None, stacklevel: Optional[int] = None
+    ) -> 'Dysco':
+        # Override the options if necessary, and construct a new instance with them.
+        readonly = self.__readonly if readonly is None else readonly
+        stacklevel = self.__stacklevel if stacklevel is None else stacklevel
+        dysco = Dysco(readonly=readonly, stacklevel=stacklevel)
+
+        # Override the instance's namespace to be the same as ours.
+        dysco.__namespace = self.__namespace
+
+        return dysco
 
     def __contains__(self, key: Hashable) -> bool:
         try:

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -21,6 +21,32 @@ async def test_async_functions():
     assert g.value == 2
 
 
+def test_calling_dysco_to_create_a_variant():
+    g.value = 1
+    readonly_g = g(readonly=True)
+
+    def check_access():
+        assert g.value == 1
+        assert readonly_g.value == 1
+
+        g.value = 2
+        assert readonly_g.value == 2
+        with pytest.raises(AttributeError):
+            readonly_g.value = 3
+
+        g.writeable_value = 4
+        readonly_g.readonly_value = 5
+
+    check_access()
+
+    assert g.value == 2
+    assert readonly_g.value == 2
+    assert 'writable_value' not in g
+    assert 'writable_value' not in readonly_g
+    assert 'readonly_value' not in g
+    assert 'readonly_value' not in readonly_g
+
+
 def test_contains():
     assert 'hi' not in g
     g['hi'] = True


### PR DESCRIPTION
This adds support for creating a new dysco instance by calling an instance like a function, and passing in any options to override. The new instance will live in the same namespace, but respect the updated configuration. For example:

```python
from dysco import g

g.value = 1

def method():
    g2 = g(readonly=True)
    # Raises an attribute error.
    g2.value = 2

method()
```
