### PR TITLE
Add decorator support

### DIFF
--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -1,8 +1,9 @@
 """Houses the implementation of the main ``Dysco`` class and project API."""
+import functools
 import inspect
 from pickle import PickleError
 from threading import Lock
-from typing import Any, Hashable, Iterator, Optional, Tuple
+from typing import Any, Callable, Hashable, Iterator, Optional, Tuple, Union
 
 from dysco.scope import Scope, find_parent_scope
 
@@ -23,14 +24,32 @@ class Dysco:
 
     def __call__(
         self,
+        function: Optional[Callable] = None,
+        *,
         readonly: Optional[bool] = None,
         shadow: Optional[bool] = None,
         stacklevel: Optional[int] = None,
-    ) -> 'Dysco':
+    ) -> Union[Callable, 'Dysco']:
         if readonly and shadow:
             raise ValueError(
                 'Only one of the "readonly" and "shadow" options can be used at the same time.'
             )
+
+        # Handle behaving like a decorator.
+        if function:
+            if inspect.iscoroutinefunction(function):
+
+                @functools.wraps(function)
+                async def wrapper(*args, **kwargs):
+                    return await function(self, *args, **kwargs)
+
+            else:
+
+                @functools.wraps(function)
+                def wrapper(*args, **kwargs):
+                    return function(self, *args, **kwargs)
+
+            return wrapper
 
         # Override the options if necessary, and construct a new instance with them.
         if readonly or shadow:

--- a/dysco/dysco.py
+++ b/dysco/dysco.py
@@ -9,7 +9,7 @@ from dysco.scope import Scope, find_parent_scope
 
 
 class Dysco:
-    def __init__(self, readonly: bool = False, shadow: bool = False, stacklevel: int = 1):
+    def __init__(self, *, readonly: bool = False, shadow: bool = False, stacklevel: int = 1):
         if readonly and shadow:
             raise ValueError(
                 'Only one of the "readonly" and "shadow" options can be used at the same time.'

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -161,6 +161,13 @@ def test_item_attribute_interoperability():
     assert g.hello == 2
 
 
+def test_keyword_only_initialization():
+    with pytest.raises(TypeError):
+        Dysco(True)
+    with pytest.raises(TypeError):
+        g(lambda: None, True)
+
+
 def test_pickling_fails():
     with pytest.raises(pickle.PickleError):
         pickle.dumps(g)

--- a/tests/test_dysco.py
+++ b/tests/test_dysco.py
@@ -21,6 +21,41 @@ async def test_async_functions():
     assert g.value == 2
 
 
+def test_calling_dysco_as_a_decorator():
+    g.value = 1
+
+    @g(readonly=True)
+    def check_access(g, arg, kwarg):
+        assert arg == 'arg'
+        assert kwarg == 'kwarg'
+        g.inner_value = 2
+        with pytest.raises(AttributeError):
+            g.value = 3
+        assert g.inner_value == 2
+
+    check_access(arg='arg', kwarg='kwarg')
+    assert g.value == 1
+    assert 'inner_value' not in g
+
+
+@pytest.mark.asyncio
+async def test_calling_dysco_as_a_decorator_on_an_async_function():
+    g.value = 1
+
+    @g(readonly=True)
+    async def check_access(g, arg, kwarg):
+        assert arg == 'arg'
+        assert kwarg == 'kwarg'
+        g.inner_value = 2
+        with pytest.raises(AttributeError):
+            g.value = 3
+        assert g.inner_value == 2
+
+    await check_access(arg='arg', kwarg='kwarg')
+    assert g.value == 1
+    assert 'inner_value' not in g
+
+
 def test_calling_dysco_to_create_a_variant():
     g.value = 1
     readonly_g = g(readonly=True)


### PR DESCRIPTION
This adds support for using an instance of dysco as a decorator to inject the instance as the first argument to the wrapped function.
