### PR TITLE
Remove python-slugify as a dependency

### DIFF
--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -18,7 +18,7 @@ name_sets_by_frame_id: Dict[int, Set[str]] = {}
 
 
 def construct_name(frame: FrameType, namespace: str = '') -> str:
-    name: str = '_dysco_'
+    name: str = '_Dysco__'
     if namespace:
         name += re.sub(r'[^_a-zA-Z0-9]+', '_', namespace)
     name += hex(id(frame.f_locals))

--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -1,10 +1,9 @@
+import re
 import weakref
 from inspect import FrameInfo
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set
 from weakref import WeakValueDictionary
-
-from slugify import slugify
 
 Stack = List[FrameInfo]
 
@@ -21,8 +20,7 @@ name_sets_by_frame_id: Dict[int, Set[str]] = {}
 def construct_name(frame: FrameType, namespace: str = '') -> str:
     name: str = '_dysco_'
     if namespace:
-        # Slugify limits characters to those matching the `[^-a-zA-Z0-9]+` regex.
-        name += slugify(namespace).replace('-', '_') + '_'
+        name += re.sub(r'[^_a-zA-Z0-9]+', '_', namespace)
     name += hex(id(frame.f_locals))
     return name
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -685,20 +685,6 @@ python-versions = "*"
 version = "2018.7"
 
 [[package]]
-category = "main"
-description = "A Python Slugify application that handles Unicode"
-name = "python-slugify"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.0.0"
-
-[package.dependencies]
-text-unidecode = ">=1.3"
-
-[package.extras]
-unidecode = ["Unidecode (>=1.1.1)"]
-
-[[package]]
 category = "dev"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
@@ -869,14 +855,6 @@ python-versions = "*"
 version = "1.1.0"
 
 [[package]]
-category = "main"
-description = "The most basic Text::Unidecode port"
-name = "text-unidecode"
-optional = false
-python-versions = "*"
-version = "1.3"
-
-[[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
@@ -1035,7 +1013,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "302c68fa551a01e464c894a0ade0cd69dca8164c076ada7d208498f4a196cc0e"
+content-hash = "fff65b1a57e0f06d111ffef48c5ca7c766a40d28eb322244c8f88eb27afc450c"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1351,9 +1329,6 @@ python-docs-theme = [
     {file = "python-docs-theme-2018.7.tar.gz", hash = "sha256:018a5bf2a7318c9c9a8346303dac8afc6bc212d92e86561c9b95a3372714155a"},
     {file = "python_docs_theme-2018.7-py2.py3-none-any.whl", hash = "sha256:f231af4bb6c9a4915e6eef319d64306f7b617f95c85aa58a92270de31e2fa507"},
 ]
-python-slugify = [
-    {file = "python-slugify-4.0.0.tar.gz", hash = "sha256:a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"},
-]
 pytz = [
     {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
     {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
@@ -1419,10 +1394,6 @@ sphinxcontrib-serializinghtml = [
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
-]
-text-unidecode = [
-    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
-    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-python-slugify = "^4.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^18.3-alpha.0", allow-prereleases = true}


### PR DESCRIPTION
This was more important when user's could specify an arbitrary namespace strings. Now the namespaces are constructed internally, and are already valid variable names. This PR removes the dependency and replaces it with a basic regex to be safe.
