### PR TITLE
Use tuples instead of strings as keys in f_locals

### DIFF
--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -2,7 +2,7 @@ import re
 import weakref
 from inspect import FrameInfo
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set
 from weakref import WeakValueDictionary
 
 Stack = List[FrameInfo]

--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -2,7 +2,7 @@ import re
 import weakref
 from inspect import FrameInfo
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Set, Tuple
 from weakref import WeakValueDictionary
 
 Stack = List[FrameInfo]
@@ -35,7 +35,7 @@ def find_existing_scope(frame: FrameType, namespace: str = '') -> Optional['Scop
     for name in name_set:
         candidate_scope = scopes_by_name.get(name)
         if candidate_scope:
-            frame_scope = frame.f_locals.get(candidate_scope.name)
+            frame_scope = frame.f_locals.get(candidate_scope.name_tuple)
             if candidate_scope is frame_scope and namespace == candidate_scope.namespace:
                 return candidate_scope
     return None
@@ -57,11 +57,12 @@ class Scope:
         self.initialized = True
 
         self.name = construct_name(frame, namespace)
+        self.name_tuple = (self.name,)
         self.namespace = namespace
         self.variables: Dict[Hashable, Any] = {}
 
         scopes_by_name[self.name] = self
-        frame.f_locals[self.name] = self
+        frame.f_locals[self.name_tuple] = self
         name_set = name_sets_by_frame_id.get(id(frame.f_locals), set())
         name_set.add(self.name)
         name_sets_by_frame_id[id(frame.f_locals)] = name_set

--- a/dysco/scope.py
+++ b/dysco/scope.py
@@ -35,7 +35,7 @@ def find_existing_scope(frame: FrameType, namespace: str = '') -> Optional['Scop
     for name in name_set:
         candidate_scope = scopes_by_name.get(name)
         if candidate_scope:
-            frame_scope = frame.f_locals.get(candidate_scope.name_tuple)
+            frame_scope = frame.f_locals.get(candidate_scope.name_tuple)  # type: ignore
             if candidate_scope is frame_scope and namespace == candidate_scope.namespace:
                 return candidate_scope
     return None
@@ -62,7 +62,7 @@ class Scope:
         self.variables: Dict[Hashable, Any] = {}
 
         scopes_by_name[self.name] = self
-        frame.f_locals[self.name_tuple] = self
+        frame.f_locals[self.name_tuple] = self  # type: ignore
         name_set = name_sets_by_frame_id.get(id(frame.f_locals), set())
         name_set.add(self.name)
         name_sets_by_frame_id[id(frame.f_locals)] = name_set

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -4,6 +4,15 @@ import inspect
 from dysco.scope import Scope, find_parent_scope, scopes_by_name
 
 
+def test_f_local_keys_are_tuples():
+    frame = inspect.stack()[0].frame
+    assert not any(isinstance(key, tuple) for key in frame.f_locals.keys())
+    Scope(frame)
+    [name_tuple] = [key for key in frame.f_locals.keys() if isinstance(key, tuple)]
+    assert len(name_tuple) == 1
+    assert name_tuple[0].startswith('_Dysco__')
+
+
 def test_namespaces_produce_new_scopes():
     frame = inspect.stack()[0].frame
     old_scope = Scope(frame)


### PR DESCRIPTION
This switches from using the name directly as a key in `f_locals` to wrapping it in a tuple of length one. This prevents the name from being injected into the scope in cases where `f_locals` is the same as `f_globals` (*e.g.* modules).
